### PR TITLE
[Fix] PortableObject: Show clone object in SetIsInPortal()

### DIFF
--- a/Assets/Scripts/PortalableObject.cs
+++ b/Assets/Scripts/PortalableObject.cs
@@ -70,7 +70,7 @@ public class PortalableObject : MonoBehaviour
 
         Physics.IgnoreCollision(collider, wallCollider);
 
-        cloneObject.SetActive(false);
+        cloneObject.SetActive(true);
 
         ++inPortalCount;
     }


### PR DESCRIPTION
I reviewed the code and noticed that `cloneObject` is not activated anywhere. Therefore, I assume that `SetIsInPortal()` inside should be changed to `true`.
Not sure if this is correct? 🤔